### PR TITLE
fix smaller fonts for longer names

### DIFF
--- a/components/scoreboard/TeamRow.js
+++ b/components/scoreboard/TeamRow.js
@@ -98,6 +98,7 @@ const TeamName = styled.div`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  font-size: ${props => props.size || '32'}px;
 `;
 
 const TeamSets = styled.div`
@@ -190,6 +191,17 @@ class TeamRow extends React.Component {
     super(props);
   }
 
+  getNameSize() {
+    const len = this.props.name.length;
+    if (len > 15) {
+      return 20;
+    }
+    if (len > 12) {
+      return 24;
+    }
+    return 32;
+  }
+
   render() {
     return (
       <Row>
@@ -197,7 +209,7 @@ class TeamRow extends React.Component {
           <Logo src={this.props.logo} />
         </LogoContainer>
         <NameAndPointContainer showBorder={this.props.showBorder}>
-          <TeamName>{this.props.name}</TeamName>
+          <TeamName size={this.getNameSize()}>{this.props.name}</TeamName>
           <TeamSets>{this.props.sets}</TeamSets>
           {/* }<PrevSetsContainer isShowing={this.props.showPrevSets}>
             <PrevSet isShowing={this.props.showPrevSets}>21</PrevSet>

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "storybook": "start-storybook -p 9001 -s ./static",
     "build-storybook": "build-storybook",
     "install-redis": "./lib/redis/install.sh",
-    "redis": "./redis/src/redis-server",
+    "redis": "./lib/redis/redis/src/redis-server",
     "lint": "node ./node_modules/eslint/bin/eslint.js ./components/** -c ./.eslintrc.json --fix",
-    "prettier": "prettier-eslint --single-quote --trailing-comma all '{components,pages,src}/**/*.js' --write"
+    "prettier":
+      "prettier-eslint --single-quote --trailing-comma all '{components,pages,src}/**/*.js' --write"
   },
   "engines": {
-    "node": "8.9.1",
-    "yarn": "1.3.2"
+    "node": "10.0.0",
+    "yarn": "1.6.0"
   },
   "dependencies": {
     "animated": "^0.2.0",


### PR DESCRIPTION
Some fonts were going out of bounds, and this was particulary impractical with beach tournaments:

![screen shot 2018-05-13 at 19 52 24](https://user-images.githubusercontent.com/6805253/39970158-2ef10274-56e7-11e8-8c95-5904b68682df.png)

The solution for now is to make the font size smaller when the length of the names increase. It is a naive solution, but it sure cant make anything worse.